### PR TITLE
delete check chunk

### DIFF
--- a/inst/tutorials/pca_recipes/pca_recipes.Rmd
+++ b/inst/tutorials/pca_recipes/pca_recipes.Rmd
@@ -355,11 +355,6 @@ pca_rec <- recipe(~., data = zoo, ) %>%
   update_role(animal_name, animal_type, new_role = "id")
 ```
 
-```{r role-check}
-pca_rec <- recipe(~., data = zoo, ) %>%
-  update_role(animal_name, animal_type, new_role = "id")
-```
-
 Try using `summary` to see the defined roles in `pca_rec` and arrange them by `role` column.
 
 ```{r role-sum, exercise=TRUE}

--- a/inst/tutorials/pca_recipes/pca_recipes.Rmd
+++ b/inst/tutorials/pca_recipes/pca_recipes.Rmd
@@ -345,13 +345,13 @@ Once we initiate the recipe, we can keep adding new [roles](https://tidymodels.g
 For example, we already told our recipe to include all variables with our formula; however, we want to exclude identifier column `animal_name` and `animal_type` from our analysis. On the other hand we need these variables later when we are plotting our results. By using `update_role()` we exclude these variables from our analysis **without** completely dropping them in the next steps:
 
 ```{r role, exercise=TRUE}
-pca_rec <- recipe(~., data = zoo, ) %>%
+pca_rec <- recipe(~., data = zoo) %>%
   # update the role for animal_name and animal_type
   update_role(___, ___, new_role = "id")
 ```
 
 ```{r role-solution}
-pca_rec <- recipe(~., data = zoo, ) %>%
+pca_rec <- recipe(~., data = zoo) %>%
   update_role(animal_name, animal_type, new_role = "id")
 ```
 


### PR DESCRIPTION
This chunk generates an error with "Submit Answer". You could use a check chunk perhaps with the following code snippet:

```
	grade_this({
		if (identical(.user_code, .solution_code)) {
			pass("Success!")
		}
		fail()
	})
```

But in that case, the exercise and solution have to be identical, meaning that you would repeat in the solution (or delete in the exercise chunk) the commented line "# update the role for animal_name and animal_type".

As you never used check chunks I suggest deleting this check chunk here.