### PR TITLE
Github repo name change for gradethis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,3 +52,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
 Remotes:
     rstudio/gradethis
+    rstudio/learnr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
 Remotes:
-    rstudio-education/gradethis
+    rstudio/gradethis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,5 +51,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
 Remotes:
-    rstudio/gradethis
+    rstudio/gradethis,
     rstudio/learnr


### PR DESCRIPTION
I don't think this is what caused [Issue 20](https://github.com/tidymodels/learntidymodels/issues/20), but I did notice this has changed while trying to troubleshoot.